### PR TITLE
Eventの型エラーを修正

### DIFF
--- a/A15/src/components/ZipCodeInput/container/composables/useInputFirst/index.ts
+++ b/A15/src/components/ZipCodeInput/container/composables/useInputFirst/index.ts
@@ -38,9 +38,12 @@ export const useInputFirst = (minLengthFirst: number) => {
   /**
    * @description - IMEが入力中の場合以外に文字を変換する。IMEが入力中かをInputEvent.isComposintで判定する。InputとCompositionの両方でfocusイベントを扱う理由は、IMEを伴う入力確定はisComposingで発行できるが、IMEを伴わない普通の英数字入力の場合はInput属性のisComposingを用いないと入力確定がチェックできないからだ。
    */
-  const handleInputFirst = (event: InputEvent) => {
-    const { target } = event
+  const handleInputFirst = (event: Event) => {
+    if (!(event instanceof InputEvent)) {
+      return
+    }
 
+    const { target } = event
     if (event.isComposing) {
       return
     }
@@ -49,7 +52,6 @@ export const useInputFirst = (minLengthFirst: number) => {
     }
 
     const textFromInput = target.value
-
     if (!event.isComposing) {
       textRefFirst.value = makeFullWidthNumToHalfWidthNum(textFromInput)
     }
@@ -59,7 +61,10 @@ export const useInputFirst = (minLengthFirst: number) => {
     }
   }
 
-  const handleCompositionEndFirst = (event: CompositionEvent) => {
+  const handleCompositionEndFirst = (event: Event) => {
+    if (!(event instanceof CompositionEvent)) {
+      return
+    }
     const { target } = event
     if (!(target instanceof HTMLInputElement)) {
       return
@@ -75,7 +80,11 @@ export const useInputFirst = (minLengthFirst: number) => {
    *
    * @description validationを行い、文字数が少ない場合にisShorterThanMinLengthをtrueにする
    */
-  const handleBlurFirst = (event: FocusEvent) => {
+  const handleBlurFirst = (event: Event) => {
+    if (!(event instanceof FocusEvent)) {
+      return
+    }
+
     const { target } = event
     if (!(target instanceof HTMLInputElement)) {
       return

--- a/A15/src/components/ZipCodeInput/container/composables/useInputSecond/index.ts
+++ b/A15/src/components/ZipCodeInput/container/composables/useInputSecond/index.ts
@@ -28,39 +28,44 @@ export const useInputSecond = (minLengthSecond: number) => {
   /**
    * @description - IMEが入力中の場合以外に文字を変換する。IMEが入力中かをInputEvent.isComposintで判定する
    */
-  const handleInputSecond = (event: InputEvent) => {
-    const { target } = event
+  const handleInputSecond = (event: Event) => {
+    if (!(event instanceof InputEvent)) {
+      return
+    }
     if (event.isComposing) {
       return
     }
+    const { target } = event
     if (!(target instanceof HTMLInputElement)) {
       return
     }
     const textFromInput = target.value
-
     if (!event.isComposing) {
       textRefSecond.value = makeFullWidthNumToHalfWidthNum(textFromInput)
     }
   }
 
-  const handleCompositionEndSecond = (event: CompositionEvent) => {
+  const handleCompositionEndSecond = (event: Event) => {
+    if (!(event instanceof CompositionEvent)) {
+      return
+    }
     const { target } = event
     if (!(target instanceof HTMLInputElement)) {
       return
     }
     const textFromInput = target.value
-
     textRefSecond.value = makeFullWidthNumToHalfWidthNum(textFromInput)
   }
 
-  const handleBlurSecond = (event: FocusEvent) => {
+  const handleBlurSecond = (event: Event) => {
+    if (!(event instanceof FocusEvent)) {
+      return
+    }
     const { target } = event
     if (!(target instanceof HTMLInputElement)) {
       return
     }
-
     const textFromInput = target.value
-
     if (textFromInput.length < minLengthSecond) {
       markShort()
     }


### PR DESCRIPTION
## 問題
https://github.com/WATA-Haru/reviewMe/issues/22

イベントハンドリングの関数でEvent型をemitで受け取っているものの、handle...の関数では詳細度の高い`FocusEvent`などを受け取るようにしていたので型の整合性が取れなくなりました。

```
    @input-first="handleInputFirst"
    @blur-first="handleBlurFirst"
    @composition-end-first="handleCompositionEndFirst"
    @input-second="handleInputSecond"
    @blur-second="handleBlurSecond"
    @composition-end-second="handleCompositionEndSecond"
```

## 解決法
`Event`で受け取り、ランタイムで型を絞り込むように修正しました。
```before.ts
const handleInputFirst = (event: InputEvent) => {
  const { target } = event
  ...
}
```
```after.ts
const handleInputFirst = (event: Event) => {
  if (!(event instanceof InputEvent)) {
    return
  }
  ...
}
```

